### PR TITLE
Add toResourceState unit test

### DIFF
--- a/src/test/toResourceState.test.ts
+++ b/src/test/toResourceState.test.ts
@@ -1,0 +1,14 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { toResourceState } from '../adapters/resourceState';
+import { FileStatus } from '../domain/JjRepository';
+
+suite('toResourceState', () => {
+    test('creates resource state from file status', () => {
+        const root = '/tmp/workspace';
+        const file: FileStatus = { path: 'foo.txt', status: 'modified' };
+        const state = toResourceState(root, file);
+        assert.strictEqual(state.resourceUri.fsPath, path.join(root, file.path));
+        assert.strictEqual(state.decorations?.tooltip, file.status);
+    });
+});


### PR DESCRIPTION
## Summary
- test toResourceState with a mock FileStatus

## Testing
- `npm run compile-tests`
- `npm run compile`
- `npm run lint`
- `npm test` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_6848d44241e48322b1eedcb3f75bd533