### PR TITLE
Add tests for JjRepository behaviors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
+        "@types/proxyquire": "^1.3.31",
+        "@types/sinon": "^17.0.4",
         "@types/vscode": "^1.100.0",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
@@ -18,10 +20,12 @@
         "esbuild": "^0.25.3",
         "eslint": "^9.25.1",
         "npm-run-all": "^4.1.5",
+        "proxyquire": "^2.1.3",
+        "sinon": "^20.0.0",
         "typescript": "^5.8.3"
       },
       "engines": {
-        "vscode": "^1.100.0"
+        "vscode": "^1.96.2"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -813,6 +817,48 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -850,6 +896,30 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/proxyquire": {
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.31.tgz",
+      "integrity": "sha512-uALowNG2TSM1HNPMMOR0AJwv4aPYPhqB0xlEhkeRTMuto5hjoSPZkvgu1nbPUkz3gEPAHv4sy4DmKsurZiEfRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.100.0",
@@ -2355,6 +2425,20 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3196,6 +3280,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -3566,6 +3660,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3630,6 +3732,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -3884,6 +3996,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4554,6 +4673,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5056,6 +5187,47 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sinon": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -5468,6 +5640,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -23,41 +23,41 @@
         "command": "jj-vsc.commit",
         "title": "JuJutsu: Commit Changes",
         "icon": {
-					"light": "resources/icons/light/check.svg",
-					"dark": "resources/icons/dark/check.svg"
-				}
+          "light": "resources/icons/light/check.svg",
+          "dark": "resources/icons/dark/check.svg"
+        }
       },
       {
         "command": "jj-vsc.show_diff",
         "title": "JuJutsu: Show Working Copy Diff",
-				"icon": {
-					"light": "resources/icons/light/discord.svg",
-					"dark": "resources/icons/dark/discord.svg"
-				}      
+        "icon": {
+          "light": "resources/icons/light/discord.svg",
+          "dark": "resources/icons/dark/discord.svg"
+        }
       },
       {
         "command": "jj-vsc.show_history",
         "title": "JuJutsu: Show History",
-				"icon": {
-					"light": "resources/icons/light/discord.svg",
-					"dark": "resources/icons/dark/discord.svg"
-				}      
+        "icon": {
+          "light": "resources/icons/light/discord.svg",
+          "dark": "resources/icons/dark/discord.svg"
+        }
       },
       {
         "command": "jj-vsc.merge_branch",
         "title": "JuJutsu: Merge Branch",
-				"icon": {
-					"light": "resources/icons/light/discord.svg",
-					"dark": "resources/icons/dark/discord.svg"
-				}      
+        "icon": {
+          "light": "resources/icons/light/discord.svg",
+          "dark": "resources/icons/dark/discord.svg"
+        }
       },
       {
         "command": "jj-vsc.refresh",
         "title": "JuJutsu: Refresh Status",
-				"icon": {
-					"light": "resources/icons/light/refresh.svg",
-					"dark": "resources/icons/dark/refresh.svg"
-				}      
+        "icon": {
+          "light": "resources/icons/light/refresh.svg",
+          "dark": "resources/icons/dark/refresh.svg"
+        }
       }
     ],
     "configuration": {
@@ -124,16 +124,20 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.100.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
+    "@types/proxyquire": "^1.3.31",
+    "@types/sinon": "^17.0.4",
+    "@types/vscode": "^1.100.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
-    "eslint": "^9.25.1",
-    "esbuild": "^0.25.3",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^5.8.3",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^2.5.2",
+    "esbuild": "^0.25.3",
+    "eslint": "^9.25.1",
+    "npm-run-all": "^4.1.5",
+    "proxyquire": "^2.1.3",
+    "sinon": "^20.0.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/src/test/JjRepository.test.ts
+++ b/src/test/JjRepository.test.ts
@@ -1,0 +1,180 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import proxyquire = require('proxyquire');
+import sinon = require('sinon');
+
+suite('JjRepository methods', () => {
+  let execFileStub: sinon.SinonStub;
+  let repoModule: typeof import('../domain/JjRepository');
+  let JjRepository: typeof import('../domain/JjRepository').JjRepository;
+  let JjExecutionError: typeof import('../domain/JjRepository').JjExecutionError;
+
+  function loadModule() {
+    execFileStub = sinon.stub();
+    repoModule = proxyquire('../domain/JjRepository', {
+      'node:child_process': { execFile: execFileStub }
+    }) as typeof import('../domain/JjRepository');
+    JjRepository = repoModule.JjRepository;
+    JjExecutionError = repoModule.JjExecutionError;
+  }
+
+  setup(loadModule);
+
+  test('status returns parsed diff', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      assert.strictEqual(args[0], 'diff');
+      cb(null, 'D a.txt\nA b.txt\n', '');
+    });
+    const repo = new JjRepository('/repo');
+    const status = await repo.status();
+    assert.deepStrictEqual(status.deleted.map(f => f.path), [path.join('/repo', 'a.txt')]);
+    assert.deepStrictEqual(status.added.map(f => f.path), [path.join('/repo', 'b.txt')]);
+  });
+
+  test('status throws on exec failure', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'boom';
+      cb(err, '', 'boom');
+    });
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.status.bind(repo), JjExecutionError);
+  });
+
+  test('commit succeeds', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      assert.strictEqual(args[0], 'commit');
+      cb(null, '', '');
+    });
+    const repo = new JjRepository('/repo');
+    await repo.commit('msg');
+    assert.ok(execFileStub.calledOnce);
+  });
+
+  test('commit requires message', async () => {
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.commit(''), /Commit message cannot be empty/);
+  });
+
+  test('commit reports nothing to commit', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'nothing to commit';
+      cb(err, '', 'nothing to commit');
+    });
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.commit('msg'), /Nothing to commit/);
+  });
+
+  test('log returns history', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      cb(null, 'first\nsecond\n', '');
+    });
+    const repo = new JjRepository('/repo');
+    const history = await repo.log();
+    assert.deepStrictEqual(history, ['first', 'second']);
+  });
+
+  test('log swallows errors', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'bad';
+      cb(err, '', 'bad');
+    });
+    const repo = new JjRepository('/repo');
+    const history = await repo.log();
+    assert.deepStrictEqual(history, []);
+  });
+
+  test('listBranches returns bookmark list', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      cb(null, 'main\nfeature\n', '');
+    });
+    const repo = new JjRepository('/repo');
+    const branches = await repo.listBranches();
+    assert.deepStrictEqual(branches, ['main', 'feature']);
+  });
+
+  test('listBranches falls back to branch list', async () => {
+    execFileStub.onFirstCall().callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'unrecognized subcommand';
+      cb(err, '', 'unrecognized subcommand');
+    });
+    execFileStub.onSecondCall().callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      cb(null, 'trunk\n', '');
+    });
+    const repo = new JjRepository('/repo');
+    const branches = await repo.listBranches();
+    assert.deepStrictEqual(branches, ['trunk']);
+  });
+
+  test('listBranches throws when both commands fail', async () => {
+    execFileStub.onFirstCall().callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'unrecognized subcommand';
+      cb(err, '', 'unrecognized subcommand');
+    });
+    execFileStub.onSecondCall().callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 2;
+      err.stderr = 'boom';
+      cb(err, '', 'boom');
+    });
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.listBranches.bind(repo), JjExecutionError);
+  });
+
+  test('mergeBranch succeeds', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      assert.strictEqual(args[0], 'new');
+      cb(null, '', '');
+    });
+    const repo = new JjRepository('/repo');
+    await repo.mergeBranch('feature');
+    assert.ok(execFileStub.calledOnce);
+  });
+
+  test('mergeBranch requires name', async () => {
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.mergeBranch(''), /Branch name cannot be empty/);
+  });
+
+  test('mergeBranch handles missing branch', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'No such revset';
+      cb(err, '', 'No such revset');
+    });
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.mergeBranch('other'), /does not exist/);
+  });
+
+  test('mergeBranch handles concurrent modification', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'Concurrent modification';
+      cb(err, '', 'Concurrent modification');
+    });
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.mergeBranch('dev'), /another process/);
+  });
+
+  test('mergeBranch rethrows other errors', async () => {
+    execFileStub.callsFake((cmd: string, args: string[], opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      const err: any = new Error('fail');
+      err.code = 1;
+      err.stderr = 'boom';
+      cb(err, '', 'boom');
+    });
+    const repo = new JjRepository('/repo');
+    await assert.rejects(repo.mergeBranch('dev'), JjExecutionError);
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive mocha tests for JjRepository methods
- include sinon + proxyquire for mocking child_process execFile
- add type declarations for new dev dependencies

## Testing
- `npm test --silent` *(fails: Missing X server when running vscode-test)*

------
https://chatgpt.com/codex/tasks/task_e_6849e46b47cc83228d3754680b701baa